### PR TITLE
Add Grafana Cloud (Loki) log ingestion and structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,22 @@ docker-compose exec ollama ollama pull <model_name>
 
 ## MCP
 Home Assistant: https://www.home-assistant.io/integrations/mcp_server/
+
+## Grafana Cloud Logs
+This bot can push structured logs directly to Grafana Cloud Logs (Loki API).
+
+1. Update `config.ini` from `config.ini.example` with your Grafana Cloud credentials in `[grafana_cloud]`.
+2. Set `LOGS_ENABLED = true`.
+3. Start the bot as usual (`uv run bot.py`).
+
+Expected values:
+- `LOGS_ENDPOINT`: Grafana Cloud Loki push endpoint (e.g., `https://logs-prod-XXX.grafana.net/loki/api/v1/push`)
+- `LOGS_USERNAME`: Grafana Cloud Logs instance ID
+- `LOGS_API_KEY`: Grafana Cloud API key with `logs:write`
+- `LOGS_APP`: app label for filtering in Explore
+
+Once running, query in Grafana Explore using labels like:
+```
+{app="scyes",service="discord-bot"}
+```
+

--- a/bot.py
+++ b/bot.py
@@ -1,83 +1,165 @@
+import time
+from typing import Any, AsyncIterator
+
+from discord import Intents, Message
 from discord.ext import commands
-from discord import Message, Intents
-from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
 from dotenv import load_dotenv
-import os
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, HumanMessage
+
+from config import app_config
 from llm.agent import astream_agent
 from llm.llm import astream
-from langchain_core.messages import AIMessageChunk
-from typing import AsyncIterator, Any
-
-from config import app_config 
+from observability.logging import configure_logging
 
 intents = Intents.default()
 intents.message_content = True
 
 load_dotenv()
 
+logger = configure_logging()
+
 bot = commands.Bot(command_prefix='>', intents=intents)
+
+
+@bot.event
+async def on_ready():
+    logger.info(
+        "Bot connected",
+        extra={"event": "bot_ready"},
+    )
+
+
+@bot.event
+async def on_command_error(ctx: commands.Context, error: Exception):
+    logger.exception(
+        "Command failed",
+        extra={
+            "event": "command_error",
+            "command": ctx.command.name if ctx.command else "unknown",
+            "guild_id": str(ctx.guild.id) if ctx.guild else "dm",
+            "channel_id": str(ctx.channel.id),
+            "user_id": str(ctx.author.id),
+        },
+    )
+    raise error
+
 
 @bot.command()
 async def ping(ctx):
     await ctx.send('pong')
+
 
 @bot.command()
 async def add(ctx, left: int, right: int):
     """Adds two numbers together."""
     await ctx.send(left + right)
 
+
 @bot.command()
 async def llm(ctx: commands.Context, *, input: str):
     """Chat with 4B model (faster responses)"""
+    start = time.perf_counter()
+    logger.info(
+        "LLM command started",
+        extra={
+            "event": "command_start",
+            "command": "llm",
+            "guild_id": str(ctx.guild.id) if ctx.guild else "dm",
+            "channel_id": str(ctx.channel.id),
+            "user_id": str(ctx.author.id),
+        },
+    )
+
     message: Message = await ctx.send("thinking...")
-    
-    msg_history: list[BaseMessage] = [AIMessage(content=msg.content) if msg.author.bot else HumanMessage(content=msg.author.name + ": " + msg.content) async for msg in message.channel.history(limit=8)]
+
+    msg_history: list[BaseMessage] = [
+        AIMessage(content=msg.content)
+        if msg.author.bot
+        else HumanMessage(content=msg.author.name + ": " + msg.content)
+        async for msg in message.channel.history(limit=8)
+    ]
 
     buffer = ""
     msg_history.reverse()
     response: AsyncIterator[AIMessageChunk] = astream(input, msg_history[:-2])
-    
+
     async for chunk in response:
         buffer += chunk.content
 
-        # If LLM output is too long, just truncate and exit for now
         if len(buffer) > 2000:
             break
 
-        # Periodically update message (e.g., every 5 chunks to reduce API load)
         if len(buffer) % 5 == 0:
             await message.edit(content=buffer + "...")
-            
-    # 4. Final update
+
     await message.edit(content=buffer)
+
+    logger.info(
+        "LLM command completed",
+        extra={
+            "event": "command_complete",
+            "command": "llm",
+            "guild_id": str(ctx.guild.id) if ctx.guild else "dm",
+            "channel_id": str(ctx.channel.id),
+            "user_id": str(ctx.author.id),
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+        },
+    )
+
 
 @bot.command()
 async def llma(ctx: commands.Context, *, input: str):
     """Chat with agent (tool calls, slower responses)"""
+    start = time.perf_counter()
+    logger.info(
+        "Agent command started",
+        extra={
+            "event": "command_start",
+            "command": "llma",
+            "guild_id": str(ctx.guild.id) if ctx.guild else "dm",
+            "channel_id": str(ctx.channel.id),
+            "user_id": str(ctx.author.id),
+        },
+    )
+
     message: Message = await ctx.send("thinking...")
-    
-    msg_history: list[BaseMessage] = [AIMessage(content=msg.content) if msg.author.bot else HumanMessage(content=msg.author.name + ": " + msg.content) async for msg in message.channel.history(limit=8)]
+
+    msg_history: list[BaseMessage] = [
+        AIMessage(content=msg.content)
+        if msg.author.bot
+        else HumanMessage(content=msg.author.name + ": " + msg.content)
+        async for msg in message.channel.history(limit=8)
+    ]
 
     buffer = ""
     msg_history.reverse()
     response: AsyncIterator[dict[str, Any] | Any] = astream_agent(input, msg_history[:-2])
-    
-    async for token, metadata in response:
+
+    async for token, _metadata in response:
         if len(token.content_blocks) == 0 or token.content_blocks[-1]["type"] != "text":
             continue
 
         buffer += token.content_blocks[0]["text"]
 
-        # If LLM output is too long, just truncate and exit for now
         if len(buffer) > 2000:
             break
 
-        # Periodically update message (e.g., every 5 chunks to reduce API load)
         if len(buffer) % 5 == 0:
             await message.edit(content=buffer + "...")
-            
-    # 4. Final update
+
     await message.edit(content=buffer)
 
-# bot.run(os.getenv("DISCORD_TOKEN"))
+    logger.info(
+        "Agent command completed",
+        extra={
+            "event": "command_complete",
+            "command": "llma",
+            "guild_id": str(ctx.guild.id) if ctx.guild else "dm",
+            "channel_id": str(ctx.channel.id),
+            "user_id": str(ctx.author.id),
+            "latency_ms": int((time.perf_counter() - start) * 1000),
+        },
+    )
+
+
 bot.run(app_config.discord_token)

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,9 +1,12 @@
+[app]
+environment = dev
+
 [database]
 host = localhost
 port = 5432
 username = app_user
-password = 
-db_name = 
+password =
+db_name =
 pool_size = 10
 ssl_enabled = true
 
@@ -16,6 +19,13 @@ debug = false
 level = INFO
 file = app.log
 
+[grafana_cloud]
+LOGS_ENABLED = false
+LOGS_ENDPOINT = https://logs-prod-XXX.grafana.net/loki/api/v1/push
+LOGS_USERNAME = <grafana_cloud_instance_id>
+LOGS_API_KEY = <grafana_cloud_api_key>
+LOGS_APP = scyes
+
 [discord]
 APP_ID =
 DISCORD_TOKEN =
@@ -27,11 +37,11 @@ LANGFUSE_PUBLIC_KEY =
 LANGFUSE_BASE_URL = https://us.cloud.langfuse.com
 
 [tavily]
-TAVILY_API_KEY = 
+TAVILY_API_KEY =
 
 [homeassistant]
-HOME_ASSISTANT_TOKEN = 
+HOME_ASSISTANT_TOKEN =
 HOME_ASSISTANT_BASE_URL = localhost
 
 [google]
-GOOGLE_API_KEY = 
+GOOGLE_API_KEY =

--- a/config.py
+++ b/config.py
@@ -9,10 +9,26 @@ class Config:
             raise FileNotFoundError(f"Config file not found: {config_file}")
         self.config.read(config_file)
 
-        self.environment: str = "dev"
+        self.environment: str = self.config.get('app', 'environment', fallback='dev')
 
         self.logging_level: str = self.config['logging'].get("level")
         self.logging_file: str = self.config['logging'].get("file")
+
+        self.grafana_cloud_logs_enabled: bool = self.config.getboolean(
+            'grafana_cloud', 'LOGS_ENABLED', fallback=False
+        )
+        self.grafana_cloud_logs_endpoint: str = self.config.get(
+            'grafana_cloud', 'LOGS_ENDPOINT', fallback=''
+        )
+        self.grafana_cloud_logs_username: str = self.config.get(
+            'grafana_cloud', 'LOGS_USERNAME', fallback=''
+        )
+        self.grafana_cloud_logs_api_key: str = self.config.get(
+            'grafana_cloud', 'LOGS_API_KEY', fallback=''
+        )
+        self.grafana_cloud_logs_app: str = self.config.get(
+            'grafana_cloud', 'LOGS_APP', fallback='scyes'
+        )
 
         self.discord_app_id: str = self.config['discord'].get("APP_ID")
         self.discord_token: str = self.config['discord'].get("DISCORD_TOKEN")
@@ -39,7 +55,5 @@ class Config:
             'pool_size': db.getint('pool_size', fallback=5)
         }
 
-    # DATABASE_URL = os.getenv("DATABASE_URL")
-    # DEBUG = os.getenv("DEBUG", "False").lower() == "true"  # Default to False
 
 app_config = Config()

--- a/observability/logging.py
+++ b/observability/logging.py
@@ -1,0 +1,109 @@
+import json
+import logging
+import time
+import base64
+from datetime import UTC, datetime
+from urllib import request
+
+from config import app_config
+
+
+class GrafanaLokiHandler(logging.Handler):
+    def __init__(self, endpoint: str, username: str, password: str, labels: dict[str, str]):
+        super().__init__()
+        self.endpoint = endpoint
+        self.username = username
+        self.password = password
+        self.labels = labels
+
+    def emit(self, record: logging.LogRecord) -> None:
+        timestamp_ns = str(int(time.time() * 1_000_000_000))
+        payload = {
+            "streams": [
+                {
+                    "stream": self.labels,
+                    "values": [[timestamp_ns, self.format(record)]],
+                }
+            ]
+        }
+
+        req = request.Request(
+            url=self.endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        req.add_header(
+            "Authorization",
+            "Basic "
+            + base64.b64encode(
+                f"{self.username}:{self.password}".encode("utf-8")
+            ).decode("ascii"),
+        )
+
+        try:
+            with request.urlopen(req, timeout=5):
+                pass
+        except Exception:
+            # Don't crash the bot on logging transport failures.
+            self.handleError(record)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        message = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        optional_fields = [
+            "event",
+            "command",
+            "guild_id",
+            "channel_id",
+            "user_id",
+            "latency_ms",
+        ]
+        for field in optional_fields:
+            if hasattr(record, field):
+                message[field] = getattr(record, field)
+
+        return json.dumps(message)
+
+
+def configure_logging() -> logging.Logger:
+    log_level = getattr(logging, app_config.logging_level.upper(), logging.INFO)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.handlers.clear()
+
+    formatter = JsonFormatter()
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    root_logger.addHandler(stream_handler)
+
+    if app_config.logging_file:
+        file_handler = logging.FileHandler(app_config.logging_file)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+    if app_config.grafana_cloud_logs_enabled:
+        loki_labels = {
+            "app": app_config.grafana_cloud_logs_app,
+            "env": app_config.environment,
+            "service": "discord-bot",
+        }
+        grafana_handler = GrafanaLokiHandler(
+            endpoint=app_config.grafana_cloud_logs_endpoint,
+            username=app_config.grafana_cloud_logs_username,
+            password=app_config.grafana_cloud_logs_api_key,
+            labels=loki_labels,
+        )
+        grafana_handler.setFormatter(formatter)
+        root_logger.addHandler(grafana_handler)
+
+    return logging.getLogger("scyes.bot")


### PR DESCRIPTION
### Motivation
- Provide structured JSON logging and optional direct ingestion to Grafana Cloud Logs (Loki) so bot telemetry (errors, command lifecycle, latency) can be surfaced and queried in Grafana.
- Centralize logging configuration to make console/file output consistent and allow toggling remote ingestion via config without changing application code.

### Description
- Add a new observability module `observability/logging.py` that implements `JsonFormatter`, a `GrafanaLokiHandler` that POSTs to Loki push API with Basic auth, and a `configure_logging()` helper to wire stream/file handlers and optionally the Grafana handler.
- Instrument `bot.py` to initialize centralized logging via `configure_logging()`, emit lifecycle and error events (`on_ready`, `on_command_error`), and log per-command start/complete events with metadata and `latency_ms` for `llm` and `llma` commands.
- Extend `config.py` to load `[app]` and `[grafana_cloud]` settings (`LOGS_ENABLED`, `LOGS_ENDPOINT`, `LOGS_USERNAME`, `LOGS_API_KEY`, `LOGS_APP`) and expose them on `app_config` for runtime configuration.
- Update `config.ini.example` with a `[grafana_cloud]` section and document setup and example queries in `README.md` to explain how to enable ingestion and query logs in Grafana.

### Testing
- Ran compilation checks with `python -m compileall bot.py config.py observability/logging.py` which completed successfully.
- Ran style/lint checks with `uv run ruff check bot.py config.py observability/logging.py` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992239b4e4832abaa882e64590c74b)